### PR TITLE
Translate reflection notebook to Korean

### DIFF
--- a/docs/docs/tutorials/reflection/reflection.ipynb
+++ b/docs/docs/tutorials/reflection/reflection.ipynb
@@ -10,15 +10,15 @@
    "id": "492f050f-3dc3-44fa-8fdc-03362afd5488",
    "metadata": {},
    "source": [
-    "# Reflection\n",
+    "# 리플렉션\n",
     "\n",
     "\n",
-    "In the context of LLM agent building, reflection refers to the process of prompting an LLM to observe its past steps (along with potential observations from tools/the environment) to assess the quality of the chosen actions.\n",
-    "This is then used downstream for things like re-planning, search, or evaluation.\n",
+    "LLM 에이전트 구축에서 리플렉션은 LLM이 과거 단계와 (도구나 환경으로부터 얻은 관찰을 포함하여) 선택한 행동의 품질을 평가하도록 프롬프트하는 과정을 의미합니다.\n",
+    "이는 이후 단계에서 재계획이나 검색, 평가 등에 사용됩니다.\n",
     "\n",
     "![Reflection](attachment:fc393f72-3401-4b86-b0d3-e4789b640a27.png)\n",
     "\n",
-    "This notebook demonstrates a very simple form of reflection in LangGraph."
+    "이 노트북은 LangGraph에서 리플렉션의 아주 간단한 형태를 보여줍니다."
    ]
   },
   {
@@ -26,9 +26,9 @@
    "id": "3ef94e7e-c9a5-4eee-a865-acf411b5c235",
    "metadata": {},
    "source": [
-    "## Setup\n",
+    "## 설정\n",
     "\n",
-    "First, let's install our required packages and set our API keys"
+    "먼저 필요한 패키지를 설치하고 API 키를 설정합시다"
    ]
   },
   {
@@ -69,9 +69,9 @@
    "metadata": {},
    "source": [
     "<div class=\"admonition tip\">\n",
-    "    <p class=\"admonition-title\">Set up <a href=\"https://smith.langchain.com\">LangSmith</a> for LangGraph development</p>\n",
+    "    <p class=\"admonition-title\">LangGraph 개발을 위해 <a href=\"https://smith.langchain.com\">LangSmith</a>를 설정하세요</p>\n",
     "    <p style=\"padding-top: 5px;\">\n",
-    "        Sign up for LangSmith to quickly spot issues and improve the performance of your LangGraph projects. LangSmith lets you use trace data to debug, test, and monitor your LLM apps built with LangGraph — read more about how to get started <a href=\"https://docs.smith.langchain.com\">here</a>. \n",
+    "        LangSmith에 가입하면 문제를 빠르게 찾아내고 LangGraph 프로젝트의 성능을 향상시킬 수 있습니다. LangSmith는 추적 데이터를 사용하여 LangGraph로 구축한 LLM 앱을 디버그하고 테스트하며 모니터링할 수 있게 해줍니다 — 시작하는 방법은 <a href=\"https://docs.smith.langchain.com\">여기</a>에서 읽어보세요. \n",
     "    </p>\n",
     "</div>"
    ]
@@ -81,9 +81,9 @@
    "id": "f27bcc4a-aaa5-46bd-8163-3e0e90cb66e6",
    "metadata": {},
    "source": [
-    "## Generate\n",
+    "## 생성\n",
     "\n",
-    "For our example, we will create a \"5 paragraph essay\" generator. First, create the generator:\n"
+    "예제로 '5단락 에세이' 생성기를 만들어 보겠습니다. 먼저 생성기를 만듭니다:\n"
    ]
   },
   {
@@ -161,7 +161,7 @@
    "id": "b0b276e7-c392-4eec-be75-c77bd130379d",
    "metadata": {},
    "source": [
-    "### Reflect"
+    "### 리플렉션"
    ]
   },
   {
@@ -238,9 +238,9 @@
    "id": "6daf926c-1174-4e96-91b9-57c57cfce40d",
    "metadata": {},
    "source": [
-    "### Repeat\n",
+    "### 반복\n",
     "\n",
-    "And... that's all there is too it! You can repeat in a loop for a fixed number of steps, or use an LLM (or other check) to decide when the finished product is good enough."
+    "그리고... 끝입니다! 정해진 횟수만큼 반복하거나 LLM(또는 다른 검증)을 사용하여 결과물이 충분히 좋은지 판단할 수 있습니다."
    ]
   },
   {
@@ -307,9 +307,9 @@
    "id": "b63a9d93-a14d-4e41-a4bb-a4cd31713f44",
    "metadata": {},
    "source": [
-    "## Define graph\n",
+    "## 그래프 정의\n",
     "\n",
-    "Now that we've shown each step in isolation, we can wire it up in a graph."
+    "각 단계를 개별적으로 살펴보았으니 이제 그래프로 연결해 보겠습니다."
    ]
   },
   {
@@ -605,9 +605,9 @@
     "jp-MarkdownHeadingCollapsed": true
    },
    "source": [
-    "## Conclusion\n",
+    "## 결론\n",
     "\n",
-    "Now that you've applied reflection to an LLM agent, I'll note one thing: self-reflection is inherently cyclic: it is much more effective if the reflection step has additional context or feedback (from tool observations, checks, etc.). If, like in the scenario above, the reflection step simply prompts the LLM to reflect on its output, it can still benefit the output quality (since the LLM then has multiple \"shots\" at getting a good output), but it's less guaranteed.\n"
+    "리플렉션을 LLM 에이전트에 적용해 보았으니 한 가지 말씀드릴 점이 있습니다. 자기 반성은 본질적으로 순환적이어서 도구 관찰이나 검증과 같은 추가 맥락이나 피드백이 있을 때 훨씬 효과적입니다. 위의 예처럼 단순히 LLM이 자신의 출력에 대해 반성하도록 지시만 한다면 출력 품질이 향상될 수 있지만(여러 번 시도해 볼 수 있으므로) 그 효과가 보장되지는 않습니다.\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- translate reflection tutorial notebook text to Korean

## Testing
- `make format`
- `make lint`
- `make test` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876feb426d083289bec45a23a60806d